### PR TITLE
Enable filter by tags

### DIFF
--- a/lua/nerveux/search.lua
+++ b/lua/nerveux/search.lua
@@ -1,6 +1,7 @@
 local M = {}
 local l = require "nerveux.log"
 local actions = require "telescope.actions"
+local action_state = require "telescope.actions.state"
 local finders = require "telescope.finders"
 local pickers = require "telescope.pickers"
 local previewers = require "telescope.previewers"
@@ -107,7 +108,7 @@ function M.search_zettel(opts)
     pickers.new({
       attach_mappings = function(_, map)
         map("i", "<tab>", function(prompt_bufnr)
-          local entry = actions.get_selected_entry()
+          local entry = action_state.get_selected_entry()
           actions.close(prompt_bufnr)
           vim.api.nvim_put({"[[" .. entry.ID .. "]]"}, "c", true, true)
         end)

--- a/lua/nerveux/search.lua
+++ b/lua/nerveux/search.lua
@@ -83,18 +83,20 @@ function M.search_zettel(opts)
   }
 
   local maker = function(deets)
+    local show_tags = function(entry)
+      return table.concat(u.map(entry["Meta"]["tags"], function(tag) return "#" .. tag end), " ")
+    end
     deets.valid = true
     deets.display = function(entry)
       return displayer {
-        table.concat(u.map(entry["Meta"]["tags"],
-                           function(tag) return "#" .. tag end), ","),
+        show_tags(entry),
         entry["Title"]
       }
     end
     deets.value = vim.fn.resolve(string.format("%s/%s",
                                                nerveux_config.neuron_dir,
                                                deets["Path"]))
-    deets.ordinal = deets["Title"]
+    deets.ordinal = show_tags(deets) .. deets["Title"]
     return deets
   end
 


### PR DESCRIPTION
This PR improves the Find/Insert Zettel menu by adding filtering by tags.
Previously, tags is only displayed, but filtering is only done by `Title` field. 